### PR TITLE
Increase filebox width

### DIFF
--- a/www/css/extra.css
+++ b/www/css/extra.css
@@ -62,3 +62,7 @@ a, .toclink, .toptoclink, .tocviewlink, .tocviewselflink, .tocviewtoggle, .plain
 .boxed {
     background: linear-gradient(to bottom left, hsl(0, 0%, 99%) 0%, hsl(293, 33%, 90%) 100%);
 }
+
+.Rfilebox {
+    margin-right: -10em;
+}

--- a/www/css/extra.css
+++ b/www/css/extra.css
@@ -64,5 +64,10 @@ a, .toclink, .toptoclink, .tocviewlink, .tocviewselflink, .tocviewtoggle, .plain
 }
 
 .Rfilebox {
-    margin-right: -14em;
+    margin-right: -15em;
 }
+
+.Rfiletitle {
+    margin-right: 15em;
+}
+

--- a/www/css/extra.css
+++ b/www/css/extra.css
@@ -64,5 +64,5 @@ a, .toclink, .toptoclink, .tocviewlink, .tocviewselflink, .tocviewtoggle, .plain
 }
 
 .Rfilebox {
-    margin-right: -10em;
+    margin-right: -14em;
 }

--- a/www/notes/basics.scrbl
+++ b/www/notes/basics.scrbl
@@ -1,6 +1,6 @@
 #lang scribble/manual
 
-@(require (for-label (except-in racket compile) a86))
+@(require (for-label (except-in racket compile)))
 @(require scribble/examples
 	  redex/reduction-semantics	  
           redex/pict

--- a/www/notes/datatypes.scrbl
+++ b/www/notes/datatypes.scrbl
@@ -1,6 +1,6 @@
 #lang scribble/manual
 
-@(require (for-label (except-in racket compile) a86))
+@(require (for-label (except-in racket compile)))
 @(require scribble/examples
 	  redex/reduction-semantics	  
           redex/pict

--- a/www/notes/dlist.scrbl
+++ b/www/notes/dlist.scrbl
@@ -1,6 +1,6 @@
 #lang scribble/manual
 
-@(require (for-label (except-in racket compile) a86))
+@(require (for-label (except-in racket compile)))
 @(require scribble/examples
 	  redex/reduction-semantics	  
           redex/pict

--- a/www/notes/folds.scrbl
+++ b/www/notes/folds.scrbl
@@ -1,6 +1,6 @@
 #lang scribble/manual
 
-@(require (for-label (except-in racket compile) a86))
+@(require (for-label (except-in racket compile)))
 @(require scribble/examples
 	  redex/reduction-semantics	  
           redex/pict

--- a/www/notes/higherorder.scrbl
+++ b/www/notes/higherorder.scrbl
@@ -1,6 +1,6 @@
 #lang scribble/manual
 
-@(require (for-label (except-in racket compile) a86))
+@(require (for-label (except-in racket compile)))
 @(require scribble/examples
 	  redex/reduction-semantics	  
           redex/pict

--- a/www/notes/treefolds.scrbl
+++ b/www/notes/treefolds.scrbl
@@ -1,6 +1,6 @@
 #lang scribble/manual
 
-@(require (for-label (except-in racket compile) a86))
+@(require (for-label (except-in racket compile)))
 @(require scribble/examples
 	  redex/reduction-semantics	  
           redex/pict

--- a/www/notes/utils.rkt
+++ b/www/notes/utils.rkt
@@ -2,7 +2,7 @@
 (provide (all-defined-out))
 (require (for-syntax racket/runtime-path racket/base racket/file))
 (require scribble/manual racket/runtime-path)
-(require (for-label (except-in racket compile) a86))
+(require (for-label (except-in racket compile)))
 (require images/icons/file)
 
 (begin-for-syntax

--- a/www/project.scrbl
+++ b/www/project.scrbl
@@ -1,5 +1,5 @@
 #lang scribble/manual
-@(require (for-label (except-in racket compile ...) a86))
+@(require (for-label (except-in racket compile ...)))
 @(require "defns.rkt")
 @(require "notes/ev.rkt")
 @(require "fancyverb.rkt")


### PR DESCRIPTION
By overriding the `margin-right` property of file boxes, we should be able to solve a lot of text overflow in notes.

(Also, the a86 dependency seems unnecessary.)