### PR TITLE
Port nix flake to {linux, darwin} x {arm, x86}

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,28 +4,39 @@
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
 
   outputs = { self, nixpkgs }:
-    let pkgs = nixpkgs.legacyPackages.x86_64-linux;
+    let
+      # Systems supported
+      allSystems = [
+        "x86_64-linux" # 64-bit Intel/AMD Linux
+        "aarch64-linux" # 64-bit ARM Linux
+        "x86_64-darwin" # 64-bit Intel macOS
+        "aarch64-darwin" # 64-bit ARM macOS
+      ];
+    forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
+        pkgs = import nixpkgs { inherit system; };
+      });
+    pkgs = nixpkgs.legacyPackages.aarch64-darwin;
         ghcPkgs = pkgs.haskellPackages.ghcWithPackages (p: with p; [
           HUnit
         ]);
-    in {
-
-    devShell.x86_64-linux = pkgs.mkShell {
-      buildInputs = [ pkgs.cargo
-                      pkgs.cabal-install
-                      pkgs.nasm
-                      pkgs.racket
-                      ghcPkgs
-                      pkgs.ocaml
-                      pkgs.ocamlPackages.findlib
-                      pkgs.ocamlPackages.utop
-                      pkgs.pandoc
-                      pkgs.rustc
-                      pkgs.rsync
-                      pkgs.texlive.combined.scheme-full
-                      pkgs.zip
-                    ];
-
+    in
+  {
+    devShells = forAllSystems ({ pkgs }: {
+      default = pkgs.mkShell {
+        packages = (with pkgs; [
+          cargo
+          cabal-install
+          nasm
+          racket
+          ghcPkgs
+          ocaml
+          ocamlPackages.findlib
+          ocamlPackages.utop
+          pandoc
+          rustc
+          rsync
+          texlive.combined.scheme-full
+          zip
+        ]); }; });
     };
-  };
 }


### PR DESCRIPTION
Using https://github.com/DeterminateSystems/zero-to-nix/blob/main/nix/templates/dev/rust/flake.nix as a template. Defined a helper that iterates over (os, arch) and outputs system specific packages